### PR TITLE
Fix status check and pause logic

### DIFF
--- a/BOT_FUNCIONAL.txt
+++ b/BOT_FUNCIONAL.txt
@@ -45,8 +45,8 @@ Sub EnviarWhatsAppWebBrave3()
 
         Status = UCase(Trim(ws.Cells(i, "G").Value)) ' Leer Status en columna G
 
-        ' SOLO PROCESAR SI STATUS = "VENCIDO"
-        If Status = "VENCIDO" Then
+        ' SOLO PROCESAR SI STATUS = "ENVIAR"
+        If Status = "ENVIAR" Then
             phone = Trim(ws.Cells(i, "C").Value)    ' Número de teléfono en columna C
             mensajeLog = Trim(ws.Cells(i, "A").Value)    ' Mensaje base en columna A
             message = mensajeLog
@@ -126,9 +126,11 @@ Sub EnviarWhatsAppWebBrave3()
             Application.Wait Now + esperaEntreTiempo / 86400
 
             contadorEnvios = contadorEnvios + 1
-            If enviosAntesPausa > 0 And contadorEnvios Mod enviosAntesPausa = 0 Then
-                pausaLargaTiempo = GetIntervalo("DuracionPausaLarga")
-                Application.Wait Now + pausaLargaTiempo / 86400
+            If enviosAntesPausa > 0 Then
+                If contadorEnvios Mod enviosAntesPausa = 0 Then
+                    pausaLargaTiempo = GetIntervalo("DuracionPausaLarga")
+                    Application.Wait Now + pausaLargaTiempo / 86400
+                End If
             End If
         End If
         

--- a/README_BOT_WA.md
+++ b/README_BOT_WA.md
@@ -8,13 +8,13 @@
 - **Columna A**: mensaje a enviar.
 - **Columna C**: número de teléfono.
 - **Columna D** (opcional): nombre del cliente.
-- **Columna G**: status. Solo si dice `"VENCIDO"` se procede con el envío.
+- **Columna G**: status. Solo si dice `"ENVIAR"` se procede con el envío.
 - **Columna H**: se marca como `"Enviado"` si fue exitoso.
 - **Columna I**: errores o resultados adicionales.
 
 ### 2. Proceso paso a paso
 1. Detecta ruta de Brave (64 o 32 bits).
-2. Si `Status = "VENCIDO"`:
+2. Si `Status = "ENVIAR"`:
    - Toma el número y mensaje.
    - Agrega nombre si está disponible.
    - Codifica el mensaje para URL.


### PR DESCRIPTION
## Summary
- update BOT_FUNCIONAL.txt so rows are processed when G column says `ENVIAR`
- avoid division by zero when long pause is configured by checking `enviosAntesPausa` before using `Mod`
- document the new behaviour in README_BOT_WA.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865f1085db4832ba084e1232eff1c05